### PR TITLE
fix issue#28 : remove invalid nodePort field from ClusterIP Service

### DIFF
--- a/Chapter12/ing.kiada.affinity-gke.yaml
+++ b/Chapter12/ing.kiada.affinity-gke.yaml
@@ -47,11 +47,9 @@ spec:
   ports:
   - name: http
     port: 80
-    nodePort: 30080
     targetPort: 8080
   - name: https
     port: 443
-    nodePort: 30443
     targetPort: 8443
 ---
 apiVersion: cloud.google.com/v1


### PR DESCRIPTION
Fixes [issue 28](https://github.com/luksa/kubernetes-in-action-2nd-edition/issues/28)