### PR TITLE
Fix gtw name in tcproute.test.yaml

### DIFF
--- a/Chapter13/tcproute.test.yaml
+++ b/Chapter13/tcproute.test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test
 spec:
   parentRefs:
-  - name: test
+  - name: test-gtw
   rules:
   - backendRefs:
     - name: test


### PR DESCRIPTION
**Fix Gateway name mismatch**

In [gtw.test.yaml](https://github.com/luksa/kubernetes-in-action-2nd-edition/blob/master/Chapter13/gtw.test.yaml#L4), the Gateway is named `test-gtw`, but in `tcproute.test.yaml` it is declared as `test`.
This change updates the `tcproute.test.yaml` file to use the correct Gateway name.
